### PR TITLE
MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Stuart Gordon Reid
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Hello, thank you for writing this software and releasing the source code, as well as your blog post on it! It's been personally useful to see how you implemented `sts` tests in Python, and I'm currently playing around with using your `RandomnessTester` to [compare my own attempts at implementing the tests](https://github.com/Honno/rngtest/blob/master/tests/randtests/test_comparisons.py).

I was wondering if you would be willing to add a permissive license to this repository, such as the widely-used [MIT license](https://choosealicense.com/licenses/mit/). This is mostly a selfish request so that I can happily keep your code in my `sts`-like program for the aforementioned comparison testing—the README disclaimer doesn't quite give me confidence in that regard—but also it would be a general nicety for you I imagine.

(MIT is simple and super permissive, allowing closed source usage. If you want it to be free to use for just open source software, you may prefer [GPLv3](https://choosealicense.com/licenses/gpl-3.0/) instead.)

I made this a pull request so it would be easy to add the license, but no worries if you're not interested in accepting it, or if you're not interested in adding a license at all for that matter!